### PR TITLE
Fix deprecations for Atom 0.209.0

### DIFF
--- a/lib/log-console.coffee
+++ b/lib/log-console.coffee
@@ -16,14 +16,17 @@ module.exports = LogConsole =
   activate: (state) ->
     @logConsoleView = new LogConsoleView()
 
-    @configPath = path.join atom.project.getPath()[0], SETTINGS_FILE_NAME
+    # TODO: This gets the path of the first project path, which may not be the
+    #       actual current project (if there are multiple project roots)
+    @configPath = path.join atom.project.getPaths()[0], SETTINGS_FILE_NAME
     fs.exists @configPath, (exists)=>
       if exists
         @load()
       else
         @logConsoleView.addLine "Couldn't find config: .log-console.json", "error"
 
-    atom.workspaceView.command "log-console:reload-config", =>
+    # TODO: Use disposable instead?
+    atom.commands.add "atom-workspace", "log-console:reload-config", =>
       @load()
 
   deactivate: ->
@@ -66,6 +69,9 @@ module.exports = LogConsole =
         @fileAndLinePattern[k] = new RegExp(v)
 
       @tail.unwatch() if @tail
+      # TODO: 1. Allow paths to be relative to project root
+      #       2. Create an error if the file does not exist
+      #          (currently throws an error from tail)
       @tail = new Tail @logConfig.logfile, @logConfig.blockSep
 
       @tail.on "line", (data)=>


### PR DESCRIPTION
This pull request fixes some deprecations in order to get `log-console` to work with Atom 0.209.0 (and probably Atom 1.0 as well).

This fixes #12 and #13 (which is proably a duplicate of #12).
